### PR TITLE
file name fixed supervisor.conf to supervisord.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Creamos el Dockerfile, con este contenido:
   CMD ["/usr/bin/supervisord"]
 ```
 
-Creamos el archivo `supervisor.conf` con este contenido:
+Creamos el archivo `supervisord.conf` con este contenido:
 
 ```
 [supervisord]


### PR DESCRIPTION
el nombre del archivo esta mal tan solo en la linea que dice 
- creamos el archivo supervisor.conf  cuando el resto del documento lo llama supervisord.conf

es algo muy simple pero hasta que te das cuenta puedes perder algún tiempo y liarte.
